### PR TITLE
Clean up anonymous container div when unmounting

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,10 @@ module.exports = function(Content, options) {
 
     componentWillUnmount: function() {
       this.removeDisplaced();
+
+      if (!options.renderTo) {
+        this.container.parentNode.removeChild(this.container);
+      }
     },
 
     renderDisplaced: function() {

--- a/test/appended-to-body.jsx
+++ b/test/appended-to-body.jsx
@@ -107,3 +107,16 @@ test('appended-to-body displaced element unmounts and mounts via `mounted` prop'
 
   t.end();
 });
+
+test('appended-to-body displaced element cleans up its container div when it unmounts', function(t) {
+  mountTestElement();
+  t.ok(document.getElementById('appended-to-body'));
+
+  var containerDiv = document.getElementById('appended-to-body').parentNode;
+  t.equal(containerDiv.parentNode, document.body);
+
+  unmountTestElement();
+  t.equal(containerDiv.parentNode, null);
+
+  t.end();
+});


### PR DESCRIPTION
When `options.renderTo` isn't set, the anonymous container div that's created to contain the displaced component wasn't being removed when the component was unmounted. Over time this could lead to lots of garbage divs being left behind in documents that frequently mount and unmount displaced components. :scream_cat: 

This PR removes anonymous container divs in `componentWillUnmount()`. :smile_cat: 
