### PR TITLE
fix StrictMode warnings by moving cWM to constructor

### DIFF
--- a/src/displace.js
+++ b/src/displace.js
@@ -24,7 +24,8 @@ function displace(WrappedComponent, options) {
 
     static WrappedComponent = WrappedComponent;
 
-    componentWillMount() {
+    constructor(props) {
+      super(props);
       this.container = (() => {
         if (!options.renderTo) {
           var result = document.createElement('div');


### PR DESCRIPTION
With React 16.3 `componentWillMount` [was deprecated](https://reactjs.org/blog/2018/03/29/react-v-16-3.html#component-lifecycle-changes) and a `StrictMode` component was introduced to help identify potential issues for the future async rendering in React.

To make this project compatible with `StrictMode`, I moved the code in `componentWillMount` to the `constructor`. Looking at the code in `componentWillMount` it was safe to move it to `constructor` since it is merely setting an instance variable and not worrying about props changes.

If this PR is approved and merged, I plan to make a similar PR to [`react-aria-modal`](https://github.com/davidtheclark/react-aria-modal) to update it to support `StrictMode`.